### PR TITLE
remove support-v4 plugin from package.json, now alreay included in the ionic android platform

### DIFF
--- a/telemetryReaderForAndroid/package.json
+++ b/telemetryReaderForAndroid/package.json
@@ -31,7 +31,6 @@
     "org.apache.cordova.device",
     "../plugins/com.monstarmike.telemetry.plugins.sharing",
     "org.apache.cordova.inappbrowser",
-    "cordova-plugin-android-support-v4",
     "../plugins/com.monstarmike.telemetry.plugins.tlmDecoder",
     "nl.x-services.plugins.socialsharing"
   ],


### PR DESCRIPTION
I updated the ionic android Platform this evening (and the android SDK after some other errors too). During the command "ionic run android", the exception "Multiple dex files define Landroid/support/v4/accessibilityservice/AccessibilityServi..." occures.
So I remove the support-v4 library from the pacakge.json because the current android platform already includes this library and we don't need to include manually. If you have the same problems, merge this change in the master. I moved it to a separate branch, to be flexible when you want to merge it.
